### PR TITLE
Adds GitHub-style math syntax (MathJax)

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -48,6 +48,9 @@
     
     <script src="/js/index.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.5.1/highlight.min.js" integrity="sha512-yUUc0qWm2rhM7X0EFe82LNnv2moqArj5nro/w1bi05A09hRVeIZbN6jlMoyu0+4I/Bu4Ck/85JQIU82T82M28w==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    {{ if .Params.math }}
+        {{ partial "mathjax.html" }}
+    {{ end }}
   </head>
   <body class="antialiased tracking-[-0.01em]">
     {{ if hugo.IsProduction -}}

--- a/layouts/partials/mathjax.html
+++ b/layouts/partials/mathjax.html
@@ -1,0 +1,14 @@
+<script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [['$','$']],
+        displayMath: [['$$','$$']],
+        processEscapes: true,
+        processEnvironments: true
+      },
+      options: {
+        skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+      }
+    };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js" id="MathJax-script"></script>


### PR DESCRIPTION
Fixes #52 

* Adds support for math inline (`$ ... $`) and block (`$$\n.....\n$$`)
* Requires setting `math: true` in relevant pages' FrontMatter