### PR TITLE
Add command name class

### DIFF
--- a/layouts/commands/single.html
+++ b/layouts/commands/single.html
@@ -8,7 +8,7 @@
     <div class="w-full max-w-[47rem] py-12">
       {{ partial "breadcrumbs" . }}
       <section class="prose prose-slate pt-10">
-        <h1>
+        <h1 class="command-name">
           {{- .Title }}
           {{- if (isset .Params "deprecated_since") }}
           <span class="text-base">(deprecated)</span>


### PR DESCRIPTION
Adds a class name for the h1 element in command titles. This lets us select this element when indexing the site for search.