### PR TITLE
Fixes command complexity's markdown rendering

### DIFF
--- a/layouts/commands/single.html
+++ b/layouts/commands/single.html
@@ -48,7 +48,7 @@
           </dd>
           {{ end }}
           <dt class="font-semibold text-slate-900">Time complexity:</dt>
-          <dd>{{ .Params.complexity | markdownify }}</dd>
+          <dd>{{ replace .Params.complexity "*" "\\*" | markdownify }}</dd>
           {{ if .Params.acl_categories }}
           <dt class="font-semibold text-slate-900">ACL categories:</dt>
             <dd>


### PR DESCRIPTION
This escapes the asterisk used in the commmands' time complexity description
to avoid it being markdownified.

Fixes https://github.com/redis/redis-doc/issues/2210 
