### PR TITLE
Set correct HUGO_VERSION in netlify config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,6 +5,7 @@
     ENV = "production"
     PYTHON_VERSION = "3.8"
     RUBY_VERSION = "2.7.2"
+    HUGO_VERSION = "0.108.0"
 
 [context.development]
   command = "make netlify"
@@ -13,6 +14,7 @@
     ENV = "development"
     PYTHON_VERSION = "3.8"
     RUBY_VERSION = "2.7.2"
+    HUGO_VERSION = "0.108.0"
 
 [context.branch-deploy]
   command = "make netlify"
@@ -21,6 +23,7 @@
     ENV = "development"
     PYTHON_VERSION = "3.8"
     RUBY_VERSION = "2.7.2"
+    HUGO_VERSION = "0.108.0"
 
 [context.deploy-preview]
   command = "make netlify"
@@ -29,3 +32,4 @@
     ENV = "deploy-preview"
     PYTHON_VERSION = "3.8"
     RUBY_VERSION = "2.7.2"
+    HUGO_VERSION = "0.108.0"


### PR DESCRIPTION
This change simplifies the life of contributors who want to set up their staging copy of redis.io for testing.
By default, Netflify uses outdated Hugo from Ubuntu's default repo. It leads to broken tabbed code widgets.