### PR TITLE
DOC-2535: fix broken GitHub links

### DIFF
--- a/build/stack/component.py
+++ b/build/stack/component.py
@@ -36,20 +36,25 @@ class Component(dict):
         self._repository = self.get('repository', None)
 
     @staticmethod
-    def _dump_payload(spath: str, dpath: str, payload: list) -> None:
+    def _dump_payload(spath: str, dpath: str, payload: list, repo: str = None, repo_branch: str = None) -> None:
         if not payload:
             return []
         files = []
         for dump in payload:
             src = dump.get('src')
             dst = dump.get('dst', src)
-            s = f'{spath}/{src}'
-            d = f'{dpath}/{dst}'
+            proc_md = dump.get('proc_md')
+            s = os.path.join(spath, src)
+            d = os.path.join(dpath, dst)
             if os.path.isfile(s):
                 mkdir_p(os.path.dirname(d))
             else:
                 mkdir_p(d)
             files += rsync(s, d)
+
+            if proc_md:
+                Component._add_meta_fm(repo, repo_branch, d, src)
+
             search = dump.get('search', None)
             replace = dump.get('replace', None)
             if search:
@@ -70,12 +75,16 @@ class Component(dict):
     def _add_meta_fm(repo: str, branch: str, base: str, path: str) -> None:
         _, dirs, files = next(os.walk(base))
         for d in dirs:
-            Component._add_meta_fm(repo, branch, f'{base}/{d}', f'{path}/{d}')
+            spath = path.split('/')[-1]
+            if spath == d:
+                Component._add_meta_fm(repo, branch, os.path.join(base, d), path)
+            else:
+                Component._add_meta_fm(repo, branch, os.path.join(base, d), os.path.join(path, d))
         for f in files:
             if not f.endswith('.md'):
                 continue
-            md = Markdown(f'{base}/{f}')
-            md.add_github_metadata(repo, branch, f'{path}/{f}')
+            md = Markdown(os.path.join(base, f))
+            md.add_github_metadata(repo, branch, os.path.join(path, f))
             md.persist()
 
     def _git_clone(self, repo) -> str:
@@ -187,10 +196,11 @@ class Component(dict):
 
     def _get_misc(self) -> None:
         misc = self.get('misc')
+        payload = misc.get('payload')
         repo = self._git_clone(misc)
         branch = Component._get_dev_branch(misc)
         self._checkout(branch, repo, misc)
-        Component._dump_payload(repo, self._root._content, misc.get('payload'))
+        Component._dump_payload(repo, self._root._content, payload, misc.get('git_uri'), branch)
         return
     
     def _repo_env_dir(self) -> str:

--- a/build/stack/component.py
+++ b/build/stack/component.py
@@ -2,6 +2,7 @@ import logging
 import glob
 import os
 import semver
+import uuid
 from typing import Tuple
 from urllib.parse import urlparse, ParseResult
 
@@ -281,9 +282,14 @@ class Stack(Component):
                 mkdir_p(path)
                 for pname, project in group.items():
                     filename = f'{path}/{slugify(gname)}_{slugify(pname)}.md'
+                    # cheap hack to workaround two (or more) clients that resolve to the same filename
+                    if kname == 'clients' and os.path.isfile(filename):
+                        uu = uuid.uuid4().hex[0:7]
+                        filename = f'{path}/{slugify(gname)}_{slugify(pname)}{uu}.md'
                     md = Markdown(filename, True)
                     md.payload = ''
                     md.fm_data['recommended'] = False
+                    md.fm_data['official'] = False
                     md.fm_data.update(project)
                     md.fm_data.update({'title': pname})
                     md.fm_data.update({'group': gname})

--- a/data/stack/stack_docs.json
+++ b/data/stack/stack_docs.json
@@ -22,23 +22,28 @@
             },
             {
                 "src": "about/",
-                "dst": "docs/about/"
+                "dst": "docs/about/",
+                "proc_md": true
             },
             {
                 "src": "docs/stack/get-started/install-stack",
-                "dst": "docs/getting-started"
+                "dst": "docs/getting-started",
+                "proc_md": true
             },
             {
                 "src": "docs/stack/get-started/om-clients",
-                "dst": "docs/clients/"
+                "dst": "docs/clients/",
+                "proc_md": true
             },
             {
                 "src": "docs/stack/about",
-                "dst": "docs"
+                "dst": "docs",
+                "proc_md": true
             },
             {
                 "src": "docs/ui/insight",
-                "dst": "docs/ui"
+                "dst": "docs/ui",
+                "proc_md": true
             }
         ]
     }

--- a/layouts/resources/bazzar.html
+++ b/layouts/resources/bazzar.html
@@ -42,8 +42,126 @@
         <h1>{{ .Title }}</h1>
         {{ with .Params.description }}<p class="text-lg -mt-5 mb-10">{{ . | markdownify }}</p>{{ end }}
         {{- .Content -}}
+
+        {{ if eq $bazzar "clients"}}
+        <h2>Official Clients</h2>
+        <dl class="mt-8">
+          <dd>
+            <div class="grid grid-cols-[repeat(16,1fr)] items-start gap-4 py-4 border-t border-slate-200/75 text-sm">
+              <div class="col-span-12 flex flex-col">
+                <a href="https://github.com/redis/NRedisStack" target="_blank">
+                  <div class="flex items-center">
+                    {{ template "icon" (dict "id" "star" "class" "mr-1 shrink-0 h-[1.125rem] w-[1.125rem] text-amber-400") }}
+                      <span class="sr-only">[official]</span>
+                    <strong>NRedisStack</strong>
+                  </div>
+                  <p class="ml-1 mt-1 mb-0">Redis Stack .Net client</p>
+                </a>
+              </div>
+              <div class="col-span-4 mr-auto">
+                <div>
+                  License: MIT
+                  <br>
+                  <a href="/docs/clients/dotnet/">.Net quickstart guide</a>
+                </div>
+              </div>
+            </div>
+          </dd>
+          <dd>
+            <div class="grid grid-cols-[repeat(16,1fr)] items-start gap-4 py-4 border-t border-slate-200/75 text-sm">
+              <div class="col-span-12 flex flex-col">
+                <a href="https://github.com/redis/go-redis" target="_blank">
+                  <div class="flex items-center">
+                    {{ template "icon" (dict "id" "star" "class" "mr-1 shrink-0 h-[1.125rem] w-[1.125rem] text-amber-400") }}
+                      <span class="sr-only">[official]</span>
+                    <strong>go-redis</strong>
+                  </div>
+                  <p class="ml-1 mt-1 mb-0">Redis Go client</p>
+                </a>
+              </div>
+              <div class="col-span-4 mr-auto">
+                <div>
+                  License: BSD-2-Clause
+                  <br>
+                  <a href="/docs/clients/go/">Go quickstart guide</a>
+                </div>
+              </div>
+            </div>
+          </dd>
+          <dd>
+            <div class="grid grid-cols-[repeat(16,1fr)] items-start gap-4 py-4 border-t border-slate-200/75 text-sm">
+              <div class="col-span-12 flex flex-col">
+                <a href="https://github.com/redis/jedis" target="_blank">
+                  <div class="flex items-center">
+                    {{ template "icon" (dict "id" "star" "class" "mr-1 shrink-0 h-[1.125rem] w-[1.125rem] text-amber-400") }}
+                      <span class="sr-only">[official]</span>
+                    <strong>Jedis</strong>
+                  </div>
+                  <p class="ml-1 mt-1 mb-0">Redis Java client</p>
+                </a>
+              </div>
+              <div class="col-span-4 mr-auto">
+                <div>
+                  License: MIT
+                  <br>
+                  <a href="/docs/clients/java/">Java quickstart guide</a>
+                </div>
+              </div>
+            </div>
+          </dd>
+          <dd>
+            <div class="grid grid-cols-[repeat(16,1fr)] items-start gap-4 py-4 border-t border-slate-200/75 text-sm">
+              <div class="col-span-12 flex flex-col">
+                <a href="https://github.com/redis/node-redis" target="_blank">
+                  <div class="flex items-center">
+                    {{ template "icon" (dict "id" "star" "class" "mr-1 shrink-0 h-[1.125rem] w-[1.125rem] text-amber-400") }}
+                      <span class="sr-only">[official]</span>
+                    <strong>node-redis</strong>
+                  </div>
+                  <p class="ml-1 mt-1 mb-0">Redis Node.js client</p>
+                </a>
+              </div>
+              <div class="col-span-4 mr-auto">
+                <div>
+                  License: MIT
+                  <br>
+                  <a href="/docs/clients/nodejs/">Node.js quickstart guide</a>
+                </div>
+              </div>
+            </div>
+          </dd>
+          <dd>
+            <div class="grid grid-cols-[repeat(16,1fr)] items-start gap-4 py-4 border-t border-slate-200/75 text-sm">
+              <div class="col-span-12 flex flex-col">
+                <a href="https://github.com/redis/redis-py" target="_blank">
+                  <div class="flex items-center">
+                    {{ template "icon" (dict "id" "star" "class" "mr-1 shrink-0 h-[1.125rem] w-[1.125rem] text-amber-400") }}
+                      <span class="sr-only">[official]</span>
+                    <strong>redis-py</strong>
+                  </div>
+                  <p class="ml-1 mt-1 mb-0">Redis Python client</p>
+                </a>
+              </div>
+              <div class="col-span-4 mr-auto">
+                <div>
+                  License: MIT
+                  <br>
+                  <a href="/docs/clients/python/">Python quickstart guide</a>
+                </div>
+              </div>
+            </div>
+          </dd>
+
+          <div class="mb-8"></div>
+        </dl>
+
+        <h2>Other Clients</h2>
+        {{ end }}
   
         <p>
+          {{ if eq $bazzar "clients"}}
+          Offical repositories are marked with a {{ template "icon" (dict "id" "star" "class" "align-text-top inline-flex shrink-0 h-[1.125rem] w-[1.125rem] color text-amber-400") }}.<br />
+          {{ end }}
           Recommended repositories are marked with a {{ template "icon" (dict "id" "heart" "class" "align-text-top inline-flex shrink-0 h-[1.125rem] w-[1.125rem] color text-red-600") }}.<br />
           Repositories with some activity within the last six months are marked with a {{ template "icon" (dict "id" "lightning" "class" "align-text-bottom inline-flex shrink-0 h-[1.0625rem] w-[1.0625rem] color text-green-500") }}.<br />
           Want your repository listed here? Just submit a PR to the <a href="https://github.com/redis/redis-doc/pull/new" target="_blank">redis-doc repository</a>.
@@ -53,10 +171,11 @@
           {{ $pages := .Resources.ByType "page" }}
           {{ range $id, $name := $groups }}
             {{ $repos := (where $pages ".Params.group" $id) }}
-            {{ $active := sort (where (where $repos ".Params.recommended" true) ".Params.active" true) ".Params.stargazers_count" "desc" }}
-            {{ $active = $active | append (sort (where (where $repos ".Params.recommended" false) ".Params.active" true) ".Params.stargazers_count" "desc") }}
-            {{ $inactive := sort (where (where $repos ".Params.recommended" true) ".Params.active" "!=" true) ".Params.stargazers_count" "desc" }}
-            {{ $inactive = $inactive | append (sort (where (where $repos ".Params.recommended" false) ".Params.active" "!=" true) ".Params.stargazers_count" "desc") }}
+            {{ $active := (where $repos ".Params.official" true) }}
+            {{ $active = $active | append (sort (where (where (where $repos ".Params.official" false) ".Params.recommended" true) ".Params.active" true) ".Params.stargazers_count" "desc") }}
+            {{ $active = $active | append (sort (where (where (where $repos ".Params.official" false) ".Params.recommended" false) ".Params.active" true) ".Params.stargazers_count" "desc") }}
+            {{ $inactive := sort (where (where (where $repos ".Params.official" false) ".Params.recommended" true) ".Params.active" "!=" true) ".Params.stargazers_count" "desc" }}
+            {{ $inactive = $inactive | append (sort (where (where (where $repos ".Params.official" false) ".Params.recommended" false) ".Params.active" "!=" true) ".Params.stargazers_count" "desc") }}
             {{ if $has_groups }}
               <dt id="{{ $id }}" class="font-semibold text-slate-900 pb-3">
                 {{- $name -}}
@@ -100,7 +219,11 @@
       <div class="col-span-12 flex flex-col">
         <a href="https://{{ .Params.repository }}" target="_blank">
           <div class="flex items-center">
-            {{ if and .Params.recommended }}
+            {{ if .Params.official }}
+            {{ template "icon" (dict "id" "star" "class" "mr-1 shrink-0 h-[1.125rem] w-[1.125rem] text-amber-400") }}
+              <span class="sr-only">[recommended]</span>
+            {{ end }}
+            {{ if .Params.recommended }}
             {{ template "icon" (dict "id" "heart" "class" "mr-1 shrink-0 h-[1.125rem] w-[1.125rem] text-red-600") }}
               <span class="sr-only">[recommended]</span>
             {{ end }}


### PR DESCRIPTION
During the redis.io site restructuring effort, some stack-related GitHub links were broken. This PR corrects this issue.