### PR TITLE
Doc time series

### DIFF
--- a/data/meta.json
+++ b/data/meta.json
@@ -3549,7 +3549,7 @@
         "open_issues_count": 117,
         "stargazers_count": 843,
         "archived": null,
-        "description": "Time Series data structure for Redis",
+        "description": "Time series data structure for Redis",
         "fetched_at": 1684063838.017459
     },
     "github.com/starkdg/Redis-ImageScout.git": {

--- a/data/stack/redistimeseries.json
+++ b/data/stack/redistimeseries.json
@@ -3,7 +3,7 @@
     "module_id": "timeseries",
     "type": "module",
     "name": "TimeSeries",
-    "description": "Time Series data structure",
+    "description": "Time series data structure",
     "stack_path": "docs/data-types/timeseries",
     "stack_weight": 150,
     "repository": {
@@ -17,8 +17,8 @@
     },
     "groups": {
         "timeseries": {
-            "display": "Time Series",
-            "description": "Operations on the Time Series data type"
+            "display": "Time series",
+            "description": "Operations on the time series data type"
         }
     },
     "docs": {

--- a/layouts/commands/list.html
+++ b/layouts/commands/list.html
@@ -51,7 +51,7 @@
             <option value="search" data-kind="stack">Search</option>
             <option value="suggestion" data-kind="stack">Auto-Suggest</option>
             <option value="tdigest" data-kind="stack">T-Digest</option>
-            <option value="timeseries" data-kind="stack">Time Series</option>
+            <option value="timeseries" data-kind="stack">Time series</option>
             <option value="topk" data-kind="stack">Top-K</option>
           </optgroup>
         </select>


### PR DESCRIPTION
Changed occurrences of 'Time Series' to 'time series' because:

* 'time series' is a common term and not a named feature
* some of our documents already used 'time series' instead of 'Time Series'
* other capabilities like 'Search and query' don't use capitalization and we want to keep it consistent