### PR TITLE
Fix menu and add redirect for broken link

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -75,7 +75,5 @@
 /commands/graph.query/ https://docs.redis.com/latest/stack/previous-features/graph/commands/
 /commands/graph.ro_query/ https://docs.redis.com/latest/stack/previous-features/graph/commands/
 /commands/graph.slowlog/ https://docs.redis.com/latest/stack/previous-features/graph/commands/
-
-
-
+/docs/stack/search/commands/ /commands/?group=search
 

--- a/config.toml
+++ b/config.toml
@@ -149,12 +149,6 @@ section = ["HTML", "RSS"] # print
     parent = "redis-stack"
     weight = 1
   [[menu.main]]
-    identifier = "stack-clients"
-    name = "Stack clients"
-    url = "/docs/clients/"
-    parent = "redis-stack"
-    weight = 2
-  [[menu.main]]
     identifier = "insight"
     name = "RedisInsight"
     url = "/docs/ui/insight/"


### PR DESCRIPTION
This PR fixes the Docs menu by removing a duplicated item. It also corrects a broken link.