### PR TITLE
Add RESP3 reply schemas to commands

### DIFF
--- a/build/stack/component.py
+++ b/build/stack/component.py
@@ -390,7 +390,7 @@ class Core(Component):
         branch = Component._get_dev_branch(data)
         self._checkout(branch, repo, data)
         logging.info(f'Getting {self._id} data')
-        for src in ['languages', 'tool_types']:
+        for src in ['languages', 'tool_types', 'resp2_replies', 'resp3_replies']:
             filename = data.get(src)
             filepath = f'{repo}/{filename}'
             rsync(filepath, 'data/')

--- a/build/stack/markdown.py
+++ b/build/stack/markdown.py
@@ -166,18 +166,26 @@ class Markdown:
 
     @staticmethod
     def convert_reply_shortcuts(payload):
-        """ Convert RESP2 reply type shortcuts to links """
+        """ Convert RESP reply type shortcuts to links """
         def reply(x):
-            resp2 = {
-                'nil': ('resp-bulk-strings', 'Null reply'),
-                'simple-string': ('resp-simple-strings', 'Simple string reply'),
-                'integer': ('resp-integers', 'Integer reply'),
-                'bulk-string': ('resp-bulk-strings', 'Bulk string reply'),
-                'array': ('resp-arrays', 'Array reply'),
-                'error': ('resp-errors', 'Error reply'),
-
+            resp = {
+                'simple-string': ('simple-strings', 'Simple string reply'),
+                'simple-error': ('simple-errors', 'Simple error reply'),
+                'integer': ('integers', 'Integer reply'),
+                'bulk-string': ('bulk-strings', 'Bulk string reply'),
+                'array': ('arrays', 'Array reply'),
+                'nil': ('bulk-strings', 'Nil reply'),
+                'null': ('nulls', 'Null reply'),
+                'boolean': ('booleans', 'Boolean reply'),
+                'double': ('doubles', 'Double reply'),
+                'big-number': ('big-numbers', 'Big number reply'),
+                'bulk-error': ('bulk-errors', 'Bulk error reply'),
+                'verbatim-string': ('verbatim-strings', 'Verbatim string reply'),
+                'map': ('maps', 'Map reply'),
+                'set': ('sets', 'Set reply'),
+                'push': ('pushes', 'Push reply')
             }
-            rep = resp2.get(x.group(1), None)
+            rep = resp.get(x.group(1), None)
             if rep:
                 return f'[{rep[1]}](/docs/reference/protocol-spec#{rep[0]})'
             return f'[]'

--- a/data/stack/redis_docs.json
+++ b/data/stack/redis_docs.json
@@ -111,6 +111,8 @@
         "git_uri": "https://github.com/redis/redis-doc",
         "dev_branch": "master",
         "languages": "languages.json",
+        "resp2_replies": "resp2_replies.json",
+        "resp3_replies": "resp3_replies.json",
         "tool_types": "tool_types.json",
         "clients": "clients/",
         "libraries": "libraries/",

--- a/layouts/commands/single.html
+++ b/layouts/commands/single.html
@@ -67,6 +67,39 @@
 
         {{ .Content }}
 
+        {{ $resp2 := index .Site.Data.resp2_replies .Params.title }}
+        {{ $resp3 := index .Site.Data.resp3_replies .Params.title }}
+        {{ if and $resp2 $resp3 }}
+          {{ $same := false }}
+          {{ $responses := slice }}
+          {{ $complement := complement $resp2 $resp3 }}
+          {{ if eq (len $complement) 0 }}
+            {{ $same = true }}
+            {{ $responses = $responses | append (slice $resp2) }}
+            {{ printf "## RESP2/RESP3 Reply" | markdownify }}
+          {{ else }}
+            {{ $responses = $responses | append (slice $resp2) }}
+            {{ $responses = $responses | append (slice $resp3) }}
+          {{ end }}
+
+          {{ $respver := 2 }}
+          {{ range $response := $responses }}
+            {{ with $response }}
+              {{ if eq $same false }}
+                {{ printf "## RESP%d Reply" $respver | markdownify }}
+                {{ $respver = add $respver 1 }}
+              {{ end }}
+              {{ $mergedString := "" }}
+              {{ range . }}
+                {{ $mergedString = print $mergedString . "\n" }}
+              {{ end }}
+              {{ $processedContent := $mergedString | markdownify }}
+              {{ $processedContent }}
+            {{ end }}
+          {{ end }}
+        {{ end }}
+        <br />
+
         {{ if isset .Params "history" }}
           <h2>History</h2>
           <ul>


### PR DESCRIPTION
Updates to support adding RESP2 and RESP3 reply schemas to all the redis-doc command files as they're processed by Hugo. Changes include:
- adding code to pull in the resp2_replies.json and resp3_replies.json files from redis-doc.
- adding/updating reply information links to the protocol spec.
- updates to the layouts/commands/single.html file to handle adding RESP schemas during doc build.