### PR TITLE
Preview of the query reorg

### DIFF
--- a/data/stack/redisearch.json
+++ b/data/stack/redisearch.json
@@ -11,7 +11,7 @@
     },
     "commands": {
         "git_uri": "https://github.com/redisearch/redisearch",
-        "dev_branch": "master",
+        "dev_branch": "doc-dmaier-query-reorg",
         "defs": "commands.json",
         "path": "docs/commands"
     },
@@ -27,7 +27,7 @@
     },
     "docs": {
         "git_uri": "https://github.com/redisearch/redisearch",
-        "dev_branch": "master",
+        "dev_branch": "doc-dmaier-query-reorg",
         "path": "docs/docs"
     },
     "releases": {


### PR DESCRIPTION
Changed the config to point to the `doc-dmaier-query-reorg` branch within    https://github.com/RediSearch/RediSearch/.